### PR TITLE
Inf file

### DIFF
--- a/README
+++ b/README
@@ -745,9 +745,18 @@ subject to conversion of '/' (which is permissible in a BBC filename) to ':'
 (which is not) so that individual filenames do not attempt to straddle Linux
 directories. 
 
-Load, Execute and Econet owner are stored as extended attributes, so you need
-to make sure your filesystem supports them. Ext4 does by default on the
-standard Pi installation. 
+By default, Load, Execute and Econet owner are stored as extended attributes,
+so you need to make sure your filesystem supports them. Ext4 does by default
+on the standard Pi installation.
+
+If your filesystem does not support extended attributes then you can use the
+-x flag to disable this, and instead the attributes are stored an in "inf"
+file.  So a filename !BOOT would have an additional !BOOT.inf that stores the
+four values.
+
+Even on a filesystem with extended attributes enabled, if an inf file is
+found then this will be used in preference, so !BOOT.inf will be used if
+it exists.
 
 You can mount each disc as a separate filesystem if you wish. The FS code will
 ignore the lost+found directory.

--- a/utilities/econet-bridge.c
+++ b/utilities/econet-bridge.c
@@ -47,6 +47,7 @@ extern void fs_eject_station(unsigned char, unsigned char); // Used to get rid o
 extern void sks_poll(int);
 extern unsigned short fs_quiet, fs_noisy;
 extern short fs_sevenbitbodge;
+extern short use_xattr; // When set use filesystem extended attributes, otherwise use a dotfile
 
 #define ECONET_LEARNED_HOST_IDLE_TIMEOUT 3600 // 1 hour
 
@@ -1609,7 +1610,7 @@ int main(int argc, char **argv)
 
 	fs_sevenbitbodge = 1; // On by default
 
-	while ((opt = getopt(argc, argv, "bc:dfilnqszh7")) != -1)
+	while ((opt = getopt(argc, argv, "bc:dfilnqsxzh7")) != -1)
 	{
 		switch (opt) {
 			case 'b': dumpmode_brief = 1; break;
@@ -1628,6 +1629,7 @@ int main(int argc, char **argv)
 				break;
 			case 's': dump_station_table = 1; break;
 			case 'z': wired_eject = 0; break;
+                        case 'x': use_xattr = 0; break;
 			case '7': fs_sevenbitbodge = 0; break;
 			case 'h':	
 				fprintf(stderr, " \n\
@@ -1646,6 +1648,7 @@ Options:\n\
 \t-l\tLocal only - do not connect to kernel module (uses /dev/null instead)\n\
 \t-q\tDisable bridge query responses\n\
 \t-s\tDump station table on startup\n\
+\t-x\tNever use filesystem extended attributes and force use of dotfiles\n\
 \t-z\tDisable wired fileserver eject on dynamic allocation (see readme)\n\
 \t-7\tDisable fileserver 7 bit bodge\n\
 \n\

--- a/utilities/remove_xattr
+++ b/utilities/remove_xattr
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+getfattr -d -R $1 | grep '^# file: ' | while read line
+do
+  filename=${line#"# file: "}
+  setfattr -x user.econet_exec $filename
+  setfattr -x user.econet_load $filename
+  setfattr -x user.econet_owner $filename
+  setfattr -x user.econet_perm $filename
+done

--- a/utilities/xattr_to_dotfile
+++ b/utilities/xattr_to_dotfile
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+getfattr -d -R $1 | while read -r line
+do
+  case $line in
+            "# file: "*) filename=${line#"# file: "}
+                         exec=0
+                         load=0
+                         owner=0
+                         perm=13
+                         ;;
+     user.econet_exec=*) exec=${line#*\"}; exec=${exec%\"} ;;
+     user.econet_load=*) load=${line#*\"}; load=${load%\"} ;;
+    user.econet_owner=*) owner=${line#*\"}; owner=${owner%\"} ;;
+     user.econet_perm=*) perm=${line#*\"}; perm=${perm%\"} ;;
+                     "") echo "$owner $load $exec $perm" > $filename.inf
+  esac
+done


### PR DESCRIPTION
Allow for -x flag to disable filesystem extended attributes.  Instead store owner/load/exec/perm in an adjunct ".inf" file.
    
We also need to track this file through RENAME and DELETE calls.

Also  two simple scripts to convert from xattr format to dotfile format
eg `xattr_to_dotfile /server_root`
then check the dotfiles look right
      `remove_xattr /server_root`
