### PR TITLE
Allow for a file "auto_inf" to automatically turn on -x mode for the bridge

### DIFF
--- a/README
+++ b/README
@@ -754,9 +754,18 @@ If your filesystem does not support extended attributes then you can use the
 file.  So a filename !BOOT would have an additional !BOOT.inf that stores the
 four values.
 
+This mode can also be enabled by creating a file called auto_inf in a
+server directory.  So, for example, if you have
+  F 0 254 32768 /econet
+then if the file /econet/auto_inf exists then it will automatically
+apply -x mode, and this will show in the log
+  FS: Attempting to initialize server 0 on 0.254 at directory /econet
+  FS: Automatically turned on -x mode because of /econet/auto_inf
+
 Even on a filesystem with extended attributes enabled, if an inf file is
 found then this will be used in preference, so !BOOT.inf will be used if
 it exists.
+
 
 You can mount each disc as a separate filesystem if you wish. The FS code will
 ignore the lost+found directory.

--- a/utilities/fs.c
+++ b/utilities/fs.c
@@ -1783,6 +1783,19 @@ int fs_initialize(unsigned char net, unsigned char stn, char *serverparam)
 
 	if (!fs_quiet) fprintf (stderr, "   FS: Attempting to initialize server %d on %d.%d at directory %s\n", fs_count, net, stn, serverparam);
 
+	// If there is a file in this directory called "auto_inf" then we
+	// automatically turn on "-x" mode.  This should work transparently
+	// for any filesystem that isn't currently inf'd 'cos reads will
+	// get the xattr and writes will create a new inf file
+	char *autoinf=malloc(strlen(serverparam)+15);
+	strcpy(autoinf,serverparam);
+	strcat(autoinf,"/auto_inf");
+	if (access(autoinf, F_OK) == 0)
+	{
+		if (!fs_quiet) fprintf(stderr, "   FS: Automatically turned on -x mode because of %s\n",autoinf);
+		use_xattr = 0;
+	}
+	free(autoinf);
 	sprintf(regex, "^(%s{1,10})", FSREGEX);
 
 	//if (regcomp(&r_pathname, "^([A-Za-z0-9\\+_;\\?/\\£\\!\\@\\%\\\\\\^\\{\\}\\+\\~\\,\\=\\<\\>\\|\\-]{1,10})", REG_EXTENDED) != 0)


### PR DESCRIPTION
This allows for a file (such as /econet/auto_inf) to automatically apply -x mode so the user doesn't need to remember to do it all the time.