### PR TITLE
Remove warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.local
 *.o
 *.ko
 module/modules.order
@@ -17,3 +18,5 @@ utilities/econet-fslist
 utilities/econet-ledtest
 utilities/econet-remote
 utilities/econet-trace
+utilities/econet-hpbridge
+utilities/econet-hpservice

--- a/include/econet-gpio.h
+++ b/include/econet-gpio.h
@@ -70,7 +70,7 @@
 
 /* Function declarations */
 
-static int econet_probe(struct platform_device *);
+//static int econet_probe(struct platform_device *);
 int econet_remove(struct platform_device *);
 int econet_open(struct inode *, struct file *);
 int econet_release(struct inode *, struct file *);

--- a/module/econet-gpio-module.c
+++ b/module/econet-gpio-module.c
@@ -1946,6 +1946,7 @@ const struct of_device_id econet_of_match[] = {
 
 MODULE_DEVICE_TABLE(of, econet_of_match);
 
+/*
 static struct platform_driver econet_driver = {
 	.driver = {
 			.name = "econet-gpio",
@@ -1954,6 +1955,7 @@ static struct platform_driver econet_driver = {
 	.probe = econet_probe,
 	.remove = econet_remove,
 };
+*/
 
 /* When a process reads from our device, this gets called. */
 ssize_t econet_readfd(struct file *flip, char *buffer, size_t len, loff_t *offset) {
@@ -2411,7 +2413,7 @@ long econet_ioctl (struct file *gp, unsigned int cmd, unsigned long arg)
 			printk (KERN_INFO "ECONET-GPIO: ioctl(set stations) called\n");
 #endif
 			/* Copy station bitmap from user memory */
-			if ((!access_ok(arg, 8192)) || copy_from_user(econet_stations, (void *) arg, 8192))
+			if ((!access_ok((void __user *)arg, 8192)) || copy_from_user(econet_stations, (void __user *) arg, 8192))
 			{
 				printk (KERN_INFO "ECONET-GPIO: Unable to update station set.\n");
 				return -EFAULT;
@@ -2713,12 +2715,14 @@ static int __init econet_init(void)
 
 /* This is known to be nasty. It should really pick all the GPIOs up from the DT - but that's the next stage... */
 
+/*
 static int __init econet_probe (struct platform_device *pdev)
 {
 
 	return econet_init();
 
 }
+*/
 
 /* Exit routine */
 

--- a/utilities/econet-bridge.c
+++ b/utilities/econet-bridge.c
@@ -2859,7 +2859,7 @@ void econet_handle_local_aun (struct __econet_packet_aun *a, int packlen, int so
 						if (((fserver = fs_get_server_id(a->p.dstnet, a->p.dststn)) != -1) && ((active_id = fs_stn_logged_in(fserver, a->p.srcnet, a->p.srcstn)) != -1))
 						{
 							fs_get_username(fserver, active_id, printjobs[found].username);
-							if (printjobs[found].username == 0) strcpy(printjobs[found].username, "ANONYMOUS");
+							if (printjobs[found].username[0]=='\0') strcpy(printjobs[found].username, "ANONYMOUS");
 							
 						}
 						else	strcpy(printjobs[found].username, "ANONYMOUS");
@@ -4106,7 +4106,7 @@ Options:\n\
 								struct __econet_packet_aun bye;
 								int netcount;
 	
-								memcpy(&(network[stn_count].s_addr), &(s->sin_addr), sizeof(struct sockaddr_in));
+								memcpy(&(network[stn_count].s_addr), s, sizeof(struct sockaddr_in));
 	
 								network[stn_count].port = ntohs(src_address.sin_port);
 								from_found = stn_count;

--- a/utilities/fs.c
+++ b/utilities/fs.c
@@ -2251,13 +2251,13 @@ int fs_initialize(struct __eb_device *device, unsigned char net, unsigned char s
 		if (!passwd)
 		{
 			fs_debug (0, 1, "No password file - initializing %s with SYST", passwordfile);
-			sprintf (users[fs_count][0].username, "%-10s", "SYST");
+			sprintf (users[fs_count][0].username, "%-9s", "SYST");
 			sprintf (users[fs_count][0].password, "%-10s", "");
 			sprintf (users[fs_count][0].fullname, "%-24s", "System User"); 
 			users[fs_count][0].priv = FS_PRIV_SYSTEM;
 			users[fs_count][0].bootopt = 0;
-			sprintf (users[fs_count][0].home, "%-96s", "$");
-			sprintf (users[fs_count][0].lib, "%-96s", "$.Library");
+			sprintf (users[fs_count][0].home, "%-95s", "$");
+			sprintf (users[fs_count][0].lib, "%-95s", "$.Library");
 			users[fs_count][0].home_disc = 0;
 			users[fs_count][0].year = users[fs_count][0].month = users[fs_count][0].day = users[fs_count][0].hour = users[fs_count][0].min = users[fs_count][0].sec = 0; // Last login time
 			if ((passwd = fopen(passwordfile, "w+")))
@@ -5883,9 +5883,9 @@ char fs_load_dequeue(int server, unsigned char net, unsigned char stn)
 		p = l->pq_head;
 		l->pq_head = l->pq_head->next;
 		free(p->packet);
-		free(p);
 
 		fs_debug (0, 4, "Packet queue entry freed at %p", p);
+		free(p);
 
 		if (!(l->pq_head)) // Ran out of packets
 		{


### PR DESCRIPTION
This just cleans up the compile so there are no warnings.

I'm not overly familiar with the code but the changes are minimal.  

It looks like the intent was for username to be 10 characters which needs 11 reserved, but changing that breaks the binary format of the user database, so I just shortened all the uses.  A bigger fix would be to do something like a text format for the database (or, heck, just use sqlite) so it's resilient to changes like that.

