### PR TITLE
Expand clock range up to 15.5us

### DIFF
--- a/include/econet-hpbridge.h
+++ b/include/econet-hpbridge.h
@@ -572,7 +572,7 @@ struct __eb_config {
 #define EB_CFG_TRUNK_NAT "^\\s*TRUNK\\s+PORT\\s+([[:digit:]]{2,5})\\s+XLATE\\s+DISTANT\\s+NET\\s+([[:digit:]]{1,3})\\s+TO\\s+LOCAL\\s+NET\\s+([[:digit:]]{1,3})\\s*$"
 #define EB_CFG_BRIDGE_NET_FILTER "^\\s*BRIDGE\\s+(DROP|ALLOW)\\s+NET\\s+(\\*|[[:digit:]]{1,3})\\s+(INBOUND|OUTBOUND)\\s+ON\\s+(WIRE\\s+NET\\s+[[:digit:]]{1,3}|TRUNK\\s+PORT\\s+[[:digit:]]{2,5})\\s*$"
 #define EB_CFG_BRIDGE_TRAFFIC_FILTER "^\\s*BRIDGE\\s+(DROP|ALLOW)\\s+TRAFFIC\\s+BETWEEN\\s+(\\*|[[:digit:]]{1,3})\\.(\\*|[[:digit:]]{1,3})\\s+AND\\s+(\\*|[[:digit:]]{1,3})\\.(\\*|[[:digit:]]{1,3})\\s*$"
-#define EB_CFG_CLOCK "^\\s*SET\\s+NETWORK\\s+CLOCK\\s+ON\\s+NET\\s+([[:digit:]]{1,3})\\s+PERIOD\\s+([345](\\.[5])?)\\s+MARK\\s+([123])\\s*$"
+#define EB_CFG_CLOCK "^\\s*SET\\s+NETWORK\\s+CLOCK\\s+ON\\s+NET\\s+([[:digit:]]{1,3})\\s+PERIOD\\s+(([3-9]|1[0-5])(\\.[5])?)\\s+MARK\\s+([123])\\s*$"
 #define EB_CFG_BINDTO "^\\s*TRUNK\\s+BIND\\s+TO\\s+(.+)\\s*$"
 // Pool system
 #define EB_CFG_NEW_POOL "^\\s*POOL\\s+([A-Z0-9]{1,10})\\s+NETS\\s+([0-9\\,]+)\\s*$"

--- a/utilities/econet-hpbridge.c
+++ b/utilities/econet-hpbridge.c
@@ -8212,7 +8212,7 @@ int eb_readconfig(char *f)
 					search->next = entry; // Put on tail
 
 			}
-			else if (!regexec(&r_netclock, line, 5, matches, 0))
+			else if (!regexec(&r_netclock, line, 6, matches, 0))
 			{
 				double	period;
 				int	mark;
@@ -8220,12 +8220,12 @@ int eb_readconfig(char *f)
 
 				net = atoi(eb_getstring(line, &matches[1]));	
 				period = atof(eb_getstring(line, &matches[2]));
-				mark = atoi(eb_getstring(line, &matches[4]));
+				mark = atoi(eb_getstring(line, &matches[5]));
 
-				if (period > 5.5 || period < 3)
+				if (period > 15.5 || period < 3)
 					eb_debug (1, 0, "CONFIG", "Bad network clock period in line %s", line);
 
-				if (mark > 2)
+				if (mark > 3)
 					eb_debug (1, 0, "CONFIG", "Bad network clock mark in line %s", line);
 
 				if (!networks[net])

--- a/utilities/econet-hpbridge.c
+++ b/utilities/econet-hpbridge.c
@@ -4568,7 +4568,7 @@ static void * eb_device_despatcher (void * device)
 			if (d->wire.period) // Clock speed to set
 			{
 				ioctl(d->wire.socket, ECONETGPIO_IOC_NETCLOCK, (d->wire.period << 16) | d->wire.mark);
-				eb_debug (0, 2, "DESPATCH", "%-8s %3d     Network clock configured", "Wire", d->net);
+				eb_debug (0, 2, "DESPATCH", "%-8s %3d     Network clock configured %.1f period / %.1f mark us", "Wire", d->net, (float) d->wire.period / 4, (float) d->wire.mark / 4);
 			}
 
 			eb_debug (0, 2, "DESPATCH", "%-8s %3d     Econet device %s opened successfully (fd %d)", "Wire", d->net, (EB_CONFIG_LOCAL ? "/dev/null" : d->wire.device), d->wire.socket);	


### PR DESCRIPTION
This allows a clock period up to 15.5us to be specified in the econet-hpbridge.cfg file, avoiding the need to manually fiddle with it using econet-clock.

Also, when running the bridge in debug mode, the clock period/mark is reported in the output.